### PR TITLE
Update target framework, remove Console.ReadKey, add CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,4 +32,4 @@ jobs:
       run: dotnet build ./DiceGameSimulation/DiceGameSimulation.sln --no-restore
     
     - name: Run
-      run: dotnet run ./DiceGameSimulation/DiceGameSimulation.csproj
+      run: dotnet run --project ./DiceGameSimulation/DiceGameSimulation.csproj

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,35 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET Build and Run
+
+on:
+  workflow_dispatch:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+    
+    - name: Restore dependencies
+      run: dotnet restore ./DiceGameSimulation/DiceGameSimulation.sln
+    
+    - name: Build
+      run: dotnet build ./DiceGameSimulation/DiceGameSimulation.sln --no-restore
+    
+    - name: Run
+      run: dotnet run ./DiceGameSimulation/DiceGameSimulation.sln

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,4 +32,4 @@ jobs:
       run: dotnet build ./DiceGameSimulation/DiceGameSimulation.sln --no-restore
     
     - name: Run
-      run: dotnet run ./DiceGameSimulation/DiceGameSimulation.sln
+      run: dotnet run ./DiceGameSimulation/DiceGameSimulation.csproj

--- a/DiceGameSimulation/DiceGameSimulation.csproj
+++ b/DiceGameSimulation/DiceGameSimulation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/DiceGameSimulation/Program.cs
+++ b/DiceGameSimulation/Program.cs
@@ -64,7 +64,6 @@ namespace DiceGameSimulation
 				Console.WriteLine($"Total {key} occurred {finalScores[key]} times.");
 			}
 			Console.WriteLine($"Total simulation took {execTime.Elapsed.TotalSeconds} seconds.");
-			Console.ReadKey();
 		}
 	}
 }


### PR DESCRIPTION
Updated DiceGameSimulation project to target .NET 9.0 in the `DiceGameSimulation.csproj` file. Removed `Console.ReadKey();` from `Program.cs` to prevent the program from waiting for a key press before closing. Added a new GitHub Actions workflow `dotnet.yml` to build and run the .NET project on pushes and pull requests to the master branch.